### PR TITLE
swig: MSVC x86 canonical names not understood

### DIFF
--- a/recipes/swig/all/conanfile.py
+++ b/recipes/swig/all/conanfile.py
@@ -77,15 +77,21 @@ class SwigConan(ConanFile):
             "--host={}".format(self.settings.arch),
             "--with-swiglibdir={}".format(self._swiglibdir),
         ]
+
+        host, build = None, None
+
         if self.settings.compiler == "Visual Studio":
             self.output.warn("Visual Studio compiler cannot create ccache-swig. Disabling ccache-swig.")
             args.append("--disable-ccache")
             self._autotools.flags.append("-FS")
+            # MSVC canonical names aren't understood
+            host, build = False, False
 
         self._autotools.libs = []
         self._autotools.library_paths = []
 
-        self._autotools.configure(args=args, configure_dir=self._source_subfolder)
+        self._autotools.configure(args=args, configure_dir=self._source_subfolder,
+                                  host=host, build=build)
         return self._autotools
 
     def _patch_sources(self):


### PR DESCRIPTION
Specify library name and version:  **swig/4.0.X**

ref https://github.com/conan-io/conan-center-index/pull/2335

With this, I can build x86

```
conan create . swig/4.0.1@ -b outdated -u -s arch=x86 -s compiler.version=16

run_in_windows_bash: "C:\Program Files\Git\usr\bin\bash.exe" --login -c ^"cd \^"/c/users/appveyor/.conan/data/swig/4.0.1/_/_/build/89d9c2644bed465799761a82444d920e57b66d30\^" ^&^& PATH=\^"/c/users/appveyor/.conan/data/winflexbison/2.5.22/_/_/package/29d1f4003b3f7143826ef1988625574513d526ce/bin:/c/users/appveyor/.conan/data/automake/1.16.2/_/_/package/3e48e69237f7f2196164383ef9dedf0f93cbf249/bin:/c/users/appveyor/.conan/data/autoconf/2.69/_/_/package/456f15897172eef340fcbac8a70811f2beb26a93/bin:/c/users/appveyor/.conan/data/m4/1.4.18/_/_/package/29d1f4003b3f7143826ef1988625574513d526ce/bin:$PATH\^" ^&^& /c/users/appveyor/.conan/data/swig/4.0.1/_/_/build/89d9c2644bed465799761a82444d920e57b66d30/source_subfolder/configure \^"PCRE_LIBS=-L\\\^"C:\Users\appveyor\.conan\data\pcre\8.41\_\_\package\78ef792a3e87cf2cad3614f2d89cfd81d2b084a8\lib\\\^" -L\\\^"C:\Users\appveyor\.conan\data\bzip2\1.0.8\_\_\package\4c88331d1c14db7a262640aef1b05d6d001a0b08\lib\\\^" -L\\\^"C:\Users\appveyor\.conan\data\zlib\1.2.11\_\_\package\429fd286eee8b832cfa3eec29b84565d7081070a\lib\\\^" -l\\\^"pcreposix\\\^" -l\\\^"pcre\\\^" -l\\\^"bz2\\\^" -l\\\^"minizip\\\^" -l\\\^"zlib\\\^"\^" \^"PCRE_CPPFLAGS=-DPCRE_STATIC=1 -DNDEBUG\^" --host=x86 --with-swiglibdir=C:/Users/appveyor/.conan/data/swig/4.0.1/_/_/package/89d9c2644bed465799761a82444d920e57b66d30/bin/swiglib --disable-ccache --prefix=C:/Users/appveyor/.conan/data/swig/4.0.1/_/_/package/89d9c2644bed465799761a82444d920e57b66d30 --build=x86_64-windows-msvc --host=i686-windows-msvc ^"
swig/4.0.1: checking build system type... Invalid configuration `x86_64-windows-msvc': system `msvc' not recognized
swig/4.0.1: 
```


Example of a failed log: https://ci.appveyor.com/project/ci-commercialbuildings/conan-openstudio-ruby/builds/34646557/job/0k5ouk82prqyivoj#L7641


- [x] I've read the [guidelines](https://github.com/conan-io/conan-center-index/wiki#how-to-submit-a-pull-request) for contributing.
- [x] I've followed the [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides for Python code in the recipes.
- [x] I've used the [latest](https://github.com/conan-io/conan/releases/latest) Conan client version.
- [x] I've tried at least one configuration locally with the
      [conan-center hook](https://github.com/conan-io/hooks.git) activated.

